### PR TITLE
Add external url for legacy pytorch package 

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -24,8 +24,7 @@ from monai.transforms import LoadImaged, Randomizable,LoadImage
 class ISIC2016(Dataset):
     def __init__(self, args, data_path , transform = None, transform_msk = None, mode = 'Training',prompt = 'click', plane = False):
 
-
-        df = pd.read_csv(os.path.join(data_path, 'ISBI2016_ISIC_Part3B_' + mode + '_GroundTruth.csv'), encoding='gbk')
+        df = pd.read_csv(os.path.join(data_path, 'ISBI2016_ISIC_Part1_' + mode + '_GroundTruth.csv'), encoding='gbk')
         self.name_list = df.iloc[:,1].tolist()
         self.label_list = df.iloc[:,2].tolist()
         self.data_path = data_path

--- a/environment.yml
+++ b/environment.yml
@@ -173,6 +173,7 @@ dependencies:
   - zlib=1.2.13=h5eee18b_0
   - zstd=1.5.5=hc292b87_0
   - pip:
+    - --extra-index-url https://download.pytorch.org/whl/cu113
     - aiosignal==1.2.0
     - alembic==1.10.4
     - appdirs==1.4.4


### PR DESCRIPTION
Without external url  in environment.xml installation of pytorch fail 
Also dataset path in dataset.py hardcoded as Part3B instead of Part1 according to readme.md